### PR TITLE
Fix RatioBox css

### DIFF
--- a/src/components/atoms/boxs/RatioBox.tsx
+++ b/src/components/atoms/boxs/RatioBox.tsx
@@ -27,6 +27,7 @@ const Container = styledComponents.div<{
   position: relative;
   width: 100%;
   max-height: ${({ maxHeight }) => maxHeight ? `${maxHeight}px` : 'none' };
+  overflow: hidden;
   &:before {
     content: "";
     display: block;


### PR DESCRIPTION
* 上部のアイテムがクリックできない問題修正
* RatioBoxが飛び出していたため、その分クリック等ができなかった
* overflow: hiddenにて対応